### PR TITLE
Bump node version from 18 to 20

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Support term of NodeJS will be ended at 30/Apr/2025.